### PR TITLE
Add Symfony 8.0 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,20 +8,25 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - 7.2
-          - 7.3
-          - 7.4
           - 8.0
           - 8.1
+          - 8.2
+          - 8.3
+          - 8.4
+          - 8.5
         symfony-version:
-          - 4.4.*
-          - 5.3.*
-          - 5.4.*
+          - 6.4.*
+          - 7.0.*
+          - 7.4.*
         include:
-          - php-version: 7.1
-            symfony-version: 4.4.*
-          - php-version: 8.1
-            symfony-version: 6.0.*
+          - php-version: 8.2
+            symfony-version: 8.0.*
+          - php-version: 8.3
+            symfony-version: 8.0.*
+          - php-version: 8.4
+            symfony-version: 8.0.*
+          - php-version: 8.5
+            symfony-version: 8.0.*
 
     steps:
       - uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -16,20 +16,20 @@
     },
     "require": {
         "php": "^8.0",
-        "symfony/config": "^6.0 || ^7.0",
-        "symfony/dependency-injection": "^6.0 || ^7.0",
+        "symfony/config": "^6.0 || ^7.0 || ^8.0",
+        "symfony/dependency-injection": "^6.0 || ^7.0 || ^8.0",
         "symfony/event-dispatcher-contracts": "^3.0",
-        "symfony/http-kernel": "^6.0 || ^7.0",
-        "symfony/property-access": "^6.0 || ^7.0",
-        "symfony/validator": "^6.0 || ^7.0",
-        "symfony/yaml": "^6.0 || ^7.0",
+        "symfony/http-kernel": "^6.0 || ^7.0 || ^8.0",
+        "symfony/property-access": "^6.0 || ^7.0 || ^8.0",
+        "symfony/validator": "^6.0 || ^7.0 || ^8.0",
+        "symfony/yaml": "^6.0 || ^7.0 || ^8.0",
         "m6web/statsd": "dev-master"
     },
     "require-dev": {
         "atoum/atoum": "^3.4 || ^4.0",
         "phpstan/phpstan": "^1.10",
-        "symfony/console": "^6.0 || ^7.0",
-        "symfony/http-foundation": "^6.0 || ^7.0"
+        "symfony/console": "^6.0 || ^7.0 || ^8.0",
+        "symfony/http-foundation": "^6.0 || ^7.0 || ^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary
- Add support for Symfony 8.0 to all symfony dependencies

## Changes
- Updated `composer.json` to allow `^6.0 || ^7.0 || ^8.0` for all Symfony packages

## Test plan
- Verify composer install works with Symfony 8.0
- Ensure existing functionality remains unchanged

## Related
- Part of Symfony 8.0 upgrade effort
- sctr/roadmap#263
- sctr/creatives.bang.com#219